### PR TITLE
Fix page order in featured area

### DIFF
--- a/template-parts/content-featured-area.php
+++ b/template-parts/content-featured-area.php
@@ -54,6 +54,7 @@ elseif ( 'select-pages' === $featured_area ) :
 		'post__in'       => checathlon_featured_pages(),
 		'posts_per_page' => checathlon_how_many_selected_pages(),
 		'no_found_rows'  => true,
+		'orderby'        => 'post__in',
 	) );
 
 endif;


### PR DESCRIPTION
I think featured content query should contain orderby attribute, because otherwise the pages will be sorted by the default parameter post date. This way when you choose page 1 on the theme customizer, the page will actually be the first one and so on.